### PR TITLE
Wrap metrics check execution under main guard

### DIFF
--- a/src/nycohm/helpers/process_datasets.py
+++ b/src/nycohm/helpers/process_datasets.py
@@ -140,7 +140,8 @@ def check_metrics():
     affordable_units_delivered = joined_df[joined_df['CompltYear'].notna()]['All_Counted_Units'].sum()
     logging.info(f'Total affordable housing units delivered: {affordable_units_delivered}')
 
-# process_housing()
-# process_affordable()
-# join_sets()
-check_metrics()
+if __name__ == "__main__":
+    # process_housing()
+    # process_affordable()
+    # join_sets()
+    check_metrics()


### PR DESCRIPTION
## Summary
- Execute `check_metrics()` only when `process_datasets.py` is run as a script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68915b7ff790832f98cddedced6871d3