### PR TITLE
Add packaging config and install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,19 @@ Making NYC housing information more accessible. Project status: pre-alpha.
 All are welcome to contribute.
 
 Current dashboard location: [https://public.tableau.com/app/profile/luke.lavanway5938/viz/NYCOpenHousingMetricsDashboardpre-alphaversion/Sheet1#1](https://public.tableau.com/app/profile/luke.lavanway5938/viz/NYCOpenHousingMetricsDashboardpre-alphaversion/Sheet1#1)
+
+## Development
+
+Install the project in editable mode so Dagster commands can locate the package:
+
+```bash
+pip install -e .
+```
+
+Run the Dagster webserver or execute the job directly:
+
+```bash
+dagster dev
+# or
+dagster job execute -m nycohm.dagster_pipeline -j nyc_housing_job
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "nycohm"
+version = "0.1.0"
+description = "NYC Open Housing Metrics package"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "dagster",
+    "dagster-webserver",
+    "pandas",
+    "google-cloud-bigquery",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/nycohm/__init__.py
+++ b/src/nycohm/__init__.py
@@ -1,0 +1,3 @@
+"""NYC Open Housing Metrics package."""
+
+__all__ = []


### PR DESCRIPTION
## Summary
- package `nycohm` via a new `pyproject.toml` using the `src` layout
- add installation and Dagster execution instructions in README
- provide minimal `nycohm` package initializer

## Testing
- `pip install -e . --no-deps`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68915b03cb64832f98e5831778f86d13