### PR TITLE
Add Dagster workspace and webserver docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,17 @@ Install the project in editable mode so Dagster commands can locate the package:
 pip install -e .
 ```
 
-Run the Dagster webserver or execute the job directly:
+Start the Dagster webserver and trigger the job from the UI:
 
 ```bash
 dagster dev
-# or
+```
+
+This uses the repository's `workspace.yaml` to load `nycohm.dagster_pipeline:defs`. Open
+<http://localhost:3000> in your browser and launch the `nyc_housing_job`.
+
+Alternatively, execute the job directly without the webserver:
+
+```bash
 dagster job execute -m nycohm.dagster_pipeline -j nyc_housing_job
 ```

--- a/workspace.yaml
+++ b/workspace.yaml
@@ -1,0 +1,4 @@
+load_from:
+  - python_module:
+      module_name: nycohm.dagster_pipeline
+      attribute: defs


### PR DESCRIPTION
## Summary
- add `workspace.yaml` so Dagster can locate `nycohm.dagster_pipeline:defs`
- document how to launch the Dagster webserver and run the job

## Testing
- `pytest`
- `PYTHONPATH="src:src/nycohm" dagster job list -w workspace.yaml` *(fails: No module named 'log_config')*


------
https://chatgpt.com/codex/tasks/task_e_68921d66b9d8832fa6692bcddd0e5aef