### PR TITLE
feat: add BigQuery client resource

### DIFF
--- a/src/nycohm/dagster_pipeline.py
+++ b/src/nycohm/dagster_pipeline.py
@@ -1,29 +1,39 @@
 from dagster import job, op, In, Out, Nothing
 
-from helpers.process_datasets import (
+from .helpers.process_datasets import (
     process_housing,
     process_affordable,
     join_sets,
 )
+from .helpers.connect_bq import bq_client
 
 
-@op(out=Out(Nothing), description="Clean and load housing dataset")
-def process_housing_op():
-    process_housing()
+@op(
+    out=Out(Nothing),
+    description="Clean and load housing dataset",
+    required_resource_keys={"bq_client"},
+)
+def process_housing_op(context):
+    process_housing(context.resources.bq_client)
 
 
-@op(out=Out(Nothing), description="Clean and load affordable housing dataset")
-def process_affordable_op():
-    process_affordable()
+@op(
+    out=Out(Nothing),
+    description="Clean and load affordable housing dataset",
+    required_resource_keys={"bq_client"},
+)
+def process_affordable_op(context):
+    process_affordable(context.resources.bq_client)
 
 
 @op(
     ins={"housing": In(Nothing), "affordable": In(Nothing)},
     out=Out(Nothing),
     description="Join processed housing datasets",
+    required_resource_keys={"bq_client"},
 )
-def join_sets_op(housing, affordable):
-    join_sets()
+def join_sets_op(context, housing, affordable):
+    join_sets(context.resources.bq_client)
 
 
 @job(description="ETL job to process NYC housing datasets and join them")
@@ -36,4 +46,8 @@ def nyc_housing_job():
 # Dagster entry point
 from dagster import Definitions
 
-defs = Definitions(jobs=[nyc_housing_job])
+
+defs = Definitions(
+    jobs=[nyc_housing_job],
+    resources={"bq_client": bq_client},
+)

--- a/src/nycohm/helpers/connect_bq.py
+++ b/src/nycohm/helpers/connect_bq.py
@@ -1,14 +1,30 @@
+from dagster import Field, resource
 from google.cloud import bigquery
 import os
-from log_config import configure_logging
+from .log_config import configure_logging
 import logging
 
 configure_logging()
 
-def connect_bq():
-    """
-    Connects to Google BigQuery using a service account key.
-    Returns a BigQuery client instance.
+
+def connect_bq(credentials_path: str | None = None) -> bigquery.Client:
+    """Return a BigQuery client using the provided credentials.
+
+    If ``credentials_path`` is ``None``, the path will be read from the
+    ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable. If no path is
+    available, the default BigQuery client behaviour is used, which relies on
+    application default credentials.
     """
 
+    path = credentials_path or os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+    if path:
+        logging.info(f"Using BigQuery credentials from {path}")
+        return bigquery.Client.from_service_account_json(path)
     return bigquery.Client()
+
+
+@resource(config_schema={"credentials_path": Field(str, is_required=False)})
+def bq_client(context) -> bigquery.Client:
+    """Dagster resource providing a :class:`bigquery.Client` instance."""
+
+    return connect_bq(context.resource_config.get("credentials_path"))

--- a/src/nycohm/helpers/load_bq.py
+++ b/src/nycohm/helpers/load_bq.py
@@ -1,12 +1,18 @@
 from google.cloud import bigquery
-from log_config import configure_logging
+from .log_config import configure_logging
 import logging
 import pandas as pd
-from connect_bq import connect_bq
 
 configure_logging()
 
-def load_bq(df, project_id, dataset_id, table_id):
+
+def load_bq(
+    df: pd.DataFrame,
+    project_id: str,
+    dataset_id: str,
+    table_id: str,
+    client: bigquery.Client,
+) -> None:
     """
     Save a DataFrame to a BigQuery table, letting BigQuery infer the schema.
 
@@ -15,8 +21,8 @@ def load_bq(df, project_id, dataset_id, table_id):
         project_id (str): The BigQuery project ID.
         dataset_id (str): The BigQuery dataset ID.
         table_id (str): The BigQuery table ID.
+        client (bigquery.Client): The BigQuery client to use.
     """
-    client = connect_bq()
     table_ref = f"{project_id}.{dataset_id}.{table_id}"
 
     # Check if the table exists


### PR DESCRIPTION
## Summary
- add Dagster BigQuery client resource configurable via env or run config
- use resource-backed client inside dataset processing helpers
- wire BigQuery resource into ops

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689223b22e24832fbec20ff1c155966b