### PR TITLE
Fix Dagster integration and pipeline dependencies

### DIFF
--- a/src/nycohm/dagster_pipeline.py
+++ b/src/nycohm/dagster_pipeline.py
@@ -37,7 +37,7 @@ def join_sets_op(context):
     description="Check metrics of the joined dataset",
     required_resource_keys={"bq_client"},
 )
-def check_metrics_op(context):
+def check_metrics_op(context, joined_data):
     check_metrics(context.resources.bq_client)
 
 
@@ -46,7 +46,7 @@ def nyc_housing_job():
     process_housing_op()
     process_affordable_op()
     joined_data = join_sets_op()
-    check_metrics_op()
+    check_metrics_op(joined_data)
 
 
 # Dagster entry point

--- a/src/nycohm/definitions.py
+++ b/src/nycohm/definitions.py
@@ -1,6 +1,7 @@
 from dagster import Definitions, define_asset_job, load_assets_from_modules
+
 from . import assets
-from .helpers.connect_bq import connect_bq
+from .helpers.connect_bq import bq_client
 
 all_assets = load_assets_from_modules([assets])
 nyc_housing_job = define_asset_job("nyc_housing_job")
@@ -8,5 +9,5 @@ nyc_housing_job = define_asset_job("nyc_housing_job")
 defs = Definitions(
     assets=all_assets,
     jobs=[nyc_housing_job],
-    resources={"bq_client": connect_bq},
+    resources={"bq_client": bq_client},
 )


### PR DESCRIPTION
## Summary
- Move Dagster definitions into package and use `bq_client` resource
- Ensure `check_metrics_op` depends on joined dataset in job

## Testing
- `pytest`
- `python -m dagster job list -w workspace.yaml --location nycohm.definitions:defs`


------
https://chatgpt.com/codex/tasks/task_e_689a226707d0832fbb7db5bb5296f389