### PR TITLE
Load Dagster definitions from file path to fix import error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,5 @@ package-dir = {"" = "src"}
 where = ["src"]
 
 [tool.dagster]
-module_name = "nycohm.definitions"
+python_file = "src/nycohm/definitions.py"
 attribute = "defs"

--- a/workspace.yaml
+++ b/workspace.yaml
@@ -1,5 +1,4 @@
 load_from:
-  - python_module:
-      module_name: nycohm.definitions
+  - python_file:
+      relative_path: src/nycohm/definitions.py
       attribute: defs
-      working_directory: src


### PR DESCRIPTION
## Summary
- configure Dagster to load definitions from the project file path so the `nycohm` package does not need to be installed
- simplify workspace configuration accordingly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3602323a8832f935b9390f7d303e4